### PR TITLE
Update various actions for node deprecation

### DIFF
--- a/.github/workflows/check-gcr.yaml
+++ b/.github/workflows/check-gcr.yaml
@@ -34,7 +34,7 @@ jobs:
     steps:
       # Setup docker GCR auth
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1
       - name: Configure resources
         run: |
           gcloud info

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -95,9 +95,9 @@ jobs:
           repository: ${{ inputs.repository }}
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Checkout deployment repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ inputs.repository }}
           token: ${{ steps.generate_token.outputs.token }}
@@ -125,7 +125,7 @@ jobs:
 
       # Setup gcloud CLI
       - name: Setup gcloud CLI
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1
         if: ${{ inputs.use_argo_sync }}
         with:
           install_components: kubectl

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -36,7 +36,7 @@ jobs:
 
       # Download and unpack build artifact
       - name: Download build result
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.artifact_key }}
       - name: Unpack artifact
@@ -44,7 +44,7 @@ jobs:
 
       # Setup docker GCR auth
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1
       - name: Configure resources
         run: |
           gcloud info

--- a/.github/workflows/rollout_canary.yaml
+++ b/.github/workflows/rollout_canary.yaml
@@ -106,7 +106,7 @@ jobs:
     runs-on: ${{ inputs.runs_on }}    
     steps:
       - name: Setup gcloud CLI
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1
         with:
           install_components: kubectl
 


### PR DESCRIPTION
Upgraded actions:
- actions/checkout@v2 to actions/checkout@v3
- actions/download-artifact@v2 to actions/download-artifact@v3
- google-github-actions/setup-gcloud@v0 to google-github-actions/setup-gcloud@v1

For google-github-actions/setup-gcloud@v1, there will be a warning like this
```
No authentication found for gcloud, authenticate with `google-github-actions/auth`.
```

Based on https://github.com/google-github-actions/setup-gcloud/issues/594, you can safely ignore the issue. Because we're using application default credentials.